### PR TITLE
Use lodash.isplainobject and lodash.zip instead whole lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "rootDir": "src"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.zip": "^4.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/mux.js
+++ b/src/mux.js
@@ -1,6 +1,6 @@
 // @flow
-import isPlainObject from 'lodash/isPlainObject';
-import zip from 'lodash/zip';
+import isPlainObject from 'lodash.isPlainObject';
+import zip from 'lodash.zip';
 
 export default async function mux(promises: any): Promise<any> {
   if (promises == null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,6 +1540,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -1548,7 +1552,11 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0:
+lodash.zip@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
+
+lodash@^4.14.0, lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Hello.

As I can see now mux depends on the full lodash module but uses only two functions: zip and isPlainObject. So excluding "lodash" and adding "lodash.zip" and "lodash.isplainobject" significantly reduce the size of the installed package.